### PR TITLE
Fix module.json parse error

### DIFF
--- a/module.json
+++ b/module.json
@@ -18,7 +18,7 @@
   "styles": [
     
   ],
-  "media:" [
+  "media": [
     {
       "type": "icon",
       "url": "https://avatars2.githubusercontent.com/u/341093?s=460&v=4"


### PR DESCRIPTION
The module.json file currently fails to parse. Here's a fix for that.
`:"` -> `":`